### PR TITLE
Add GitHub Actions workflow for team content pipeline

### DIFF
--- a/.github/workflows/run-team-pipeline.yml
+++ b/.github/workflows/run-team-pipeline.yml
@@ -1,0 +1,39 @@
+name: Run T4L Team Content Pipeline
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # Runs daily at 01:00 am UTC
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Install Playwright browsers
+        run: |
+          python -m playwright install --with-deps chromium
+          
+      - name: Run team pipeline
+        run: python teamPipeline.py
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          # Add any other environment variables used in your application


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automates the execution of the team content pipeline. The workflow is scheduled to run daily at 01:00 am UTC and can also be triggered manually.

The workflow includes steps for checking out the code, setting up Python, installing dependencies, and running the team pipeline script. Environment variables are securely managed using GitHub secrets, ensuring sensitive information is not exposed.