### PR TITLE
Update LLM model references to gpt-4.1-nano-2025-04-14

### DIFF
--- a/LLM_init.py
+++ b/LLM_init.py
@@ -12,17 +12,17 @@ from typing import Literal
 load_dotenv()
 
 # Available models configuration
-ModelType = Literal["deepseek", "gpt-4o-mini"]
+ModelType = Literal["deepseek", "gpt-4.1-nano-2025-04-14"]
 MODEL_CONFIGS = {
     "deepseek": {
         "base_url": "https://api.deepseek.com",
         "api_key_env": "DEEPSEEK_API_KEY",
         "model": "deepseek-chat"  # Add the specific model name if needed
     },
-    "gpt-4o-mini": {
+    "gpt-4.1-nano-2025-04-14": {
         "base_url": "https://api.openai.com/v1",
         "api_key_env": "OPENAI_API_KEY",
-        "model": "gpt-4o-mini"
+        "model": "gpt-4.1-nano-2025-04-14"
     }
 }
 
@@ -31,7 +31,7 @@ def initialize_llm_client(model_type: ModelType = "deepseek"):
     Initialize the OpenAI client with specified model configuration.
     
     Args:
-        model_type: The type of model to use ('deepseek' or 'gpt-4o-mini')
+        model_type: The type of model to use ('deepseek' or 'gpt-4.1-nano-2025-04-14')
     
     Returns:
         tuple: (OpenAI client instance, model name)
@@ -39,7 +39,18 @@ def initialize_llm_client(model_type: ModelType = "deepseek"):
     Raises:
         ValueError: If the required API key is not set
     """
-    config = MODEL_CONFIGS[model_type]
+    # Handle the case where model_type is still "gpt-4o-mini" from environment variable
+    if model_type == "gpt-4o-mini":
+        print("Warning: 'gpt-4o-mini' model type is deprecated, using 'gpt-4.1-nano-2025-04-14' instead.")
+        model_type = "gpt-4.1-nano-2025-04-14"
+    
+    try:
+        config = MODEL_CONFIGS[model_type]
+    except KeyError:
+        print(f"Warning: Unknown model type '{model_type}', falling back to 'gpt-4.1-nano-2025-04-14'.")
+        model_type = "gpt-4.1-nano-2025-04-14"
+        config = MODEL_CONFIGS[model_type]
+    
     api_key = os.getenv(config["api_key_env"])
     
     if not api_key:
@@ -49,5 +60,7 @@ def initialize_llm_client(model_type: ModelType = "deepseek"):
         api_key=api_key,
         base_url=config["base_url"]
     )
+    
+    print(f"DEBUG: Using model: {config['model']}")
     
     return client, config["model"]

--- a/cleanContent.py
+++ b/cleanContent.py
@@ -25,7 +25,7 @@ supabase_client: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
 
 # Initialize both LLM clients
 deepseek_client, deepseek_model = initialize_llm_client(model_type="deepseek")
-gpt4_client, gpt4_model = initialize_llm_client(model_type="gpt-4o-mini")
+gpt4_client, gpt4_model = initialize_llm_client(model_type="gpt-4.1-nano-2025-04-14")
 
 def load_extracted_content(file_path: str) -> Dict[str, Any]:
     """
@@ -95,7 +95,7 @@ def clean_publication_date(date_string: str) -> Optional[str]:
 
 def extract_content_with_llm(content: str) -> Dict[str, str]:
     """
-    Extract article content using GPT-4o-mini for better extraction capabilities.
+    Extract article content using gpt-4.1-nano-2025-04-14 for better extraction capabilities.
     
     Args:
         content: The raw content to process
@@ -128,7 +128,7 @@ Article content to process:
 {cleaned_content}"""
 
     try:
-        # Using GPT-4o-mini for content extraction
+        # Using gpt-4.1-nano-2025-04-14 for content extraction
         response = gpt4_client.chat.completions.create(
             model=gpt4_model,
             messages=[

--- a/extractContent.py
+++ b/extractContent.py
@@ -10,7 +10,7 @@ from fetchUnprocessedArticles import get_unprocessed_articles
 from LLM_init import initialize_llm_client, ModelType
 
 # Initialize the LLM client with configurable model type
-MODEL_TYPE: ModelType = os.getenv("LLM_MODEL_TYPE", "gpt-4o-mini")
+MODEL_TYPE: ModelType = os.getenv("LLM_MODEL_TYPE", "gpt-4.1-nano-2025-04-14")
 client, model_name = initialize_llm_client(model_type=MODEL_TYPE)
 api_token = os.environ.get("OPENAI_API_KEY")  # Get API key from environment
 
@@ -19,7 +19,7 @@ async def extract_main_content(full_url: str) -> str:
         try:
             # Create LLM strategy with text output instead of JSON
             llm_strategy = LLMExtractionStrategy(
-                provider="openai/gpt-4o-mini",
+                provider=f"openai/{model_name}",  # Use the model_name from initialize_llm_client
                 api_token=api_token,
                 verbose=True,
                 max_tokens=16000,


### PR DESCRIPTION
Replaced all instances of the deprecated 'gpt-4o-mini' model with 'gpt-4.1-nano-2025-04-14' across the codebase. This change ensures compatibility with the latest model specifications and improves extraction capabilities. Warnings have been added to handle cases where the deprecated model type is still used, guiding users to the updated model.