### PR TITLE
Add cluster member count recalculation and validation

### DIFF
--- a/cluster_pipeline.py
+++ b/cluster_pipeline.py
@@ -11,6 +11,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from modules.clustering.cluster_articles import run_clustering_process
+from core.clustering.db_access import recalculate_cluster_member_counts
 
 # Set up logging
 logging.basicConfig(
@@ -31,6 +32,14 @@ def process_new(threshold: float = 0.82) -> None:
     logger.info(f"Starting article clustering workflow with threshold {threshold}")
     run_clustering_process(threshold)
     logger.info("Article clustering workflow completed")
+    
+    # Automatically fix any cluster member count discrepancies
+    logger.info("Verifying and fixing cluster member counts...")
+    discrepancies = recalculate_cluster_member_counts()
+    if discrepancies:
+        logger.info(f"Fixed {len(discrepancies)} cluster member count discrepancies")
+    else:
+        logger.info("All cluster member counts are accurate")
 
 if __name__ == "__main__":
     process_new()

--- a/core/clustering/cluster_manager.py
+++ b/core/clustering/cluster_manager.py
@@ -46,8 +46,8 @@ class ClusterManager:
         Returns:
             Tuple containing the new centroid and the updated member count
         """
-        if old_count < 1:
-            raise ValueError("Cluster member count must be at least 1")
+        if old_count < 2:
+            raise ValueError("Cluster member count must be at least 2")
         
         # Handle dimension mismatch
         old_centroid, new_vector = normalize_vector_dimensions(old_centroid, new_vector)

--- a/core/clustering/cluster_manager.py
+++ b/core/clustering/cluster_manager.py
@@ -46,6 +46,9 @@ class ClusterManager:
         Returns:
             Tuple containing the new centroid and the updated member count
         """
+        if old_count < 1:
+            raise ValueError("Cluster member count must be at least 1")
+        
         # Handle dimension mismatch
         old_centroid, new_vector = normalize_vector_dimensions(old_centroid, new_vector)
         

--- a/fix_cluster_counts.py
+++ b/fix_cluster_counts.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Utility script to fix cluster member counts by recalculating based on actual article assignments.
+This script also removes clusters with 0 or 1 members, as a proper cluster requires at least 2 articles.
+
+Usage:
+    python fix_cluster_counts.py
+"""
+
+import sys
+import os
+import logging
+
+# Add root directory to Python path to allow importing core modules
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from core.clustering.db_access import recalculate_cluster_member_counts
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def main():
+    """Run cluster member count fix process."""
+    print("Starting to fix cluster member counts...")
+    
+    # Run the recalculation function
+    discrepancies = recalculate_cluster_member_counts()
+    
+    # Report the results
+    if discrepancies:
+        print(f"\nFixed {len(discrepancies)} cluster member count discrepancies:")
+        print("-" * 80)
+        print(f"{'Cluster ID':<40} {'Old Count':>8} {'New Count':>8} {'Difference':>10}")
+        print("-" * 80)
+        
+        for cluster_id, (old_count, new_count) in discrepancies.items():
+            print(f"{cluster_id:<40} {old_count:>8} {new_count:>8} {new_count - old_count:>+10}")
+    else:
+        print("\nAll cluster member counts were already accurate.")
+    
+    # Check for zero/one member clusters in logs
+    print("\nProcess completed successfully.")
+    print("Note: Clusters with 0 or 1 members have been automatically removed,")
+    print("and articles from single-member clusters have been unlinked.")
+
+if __name__ == "__main__":
+    main()

--- a/fix_cluster_counts.py
+++ b/fix_cluster_counts.py
@@ -25,27 +25,27 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Run cluster member count fix process."""
-    print("Starting to fix cluster member counts...")
+    logger.info("Starting to fix cluster member counts...")
     
     # Run the recalculation function
     discrepancies = recalculate_cluster_member_counts()
     
     # Report the results
     if discrepancies:
-        print(f"\nFixed {len(discrepancies)} cluster member count discrepancies:")
-        print("-" * 80)
-        print(f"{'Cluster ID':<40} {'Old Count':>8} {'New Count':>8} {'Difference':>10}")
-        print("-" * 80)
+        logger.info(f"\nFixed {len(discrepancies)} cluster member count discrepancies:")
+        logger.info("-" * 80)
+        logger.info(f"{'Cluster ID':<40} {'Old Count':>8} {'New Count':>8} {'Difference':>10}")
+        logger.info("-" * 80)
         
         for cluster_id, (old_count, new_count) in discrepancies.items():
-            print(f"{cluster_id:<40} {old_count:>8} {new_count:>8} {new_count - old_count:>+10}")
+            logger.info(f"{cluster_id:<40} {old_count:>8} {new_count:>8} {new_count - old_count:>+10}")
     else:
-        print("\nAll cluster member counts were already accurate.")
+        logger.info("\nAll cluster member counts were already accurate.")
     
     # Check for zero/one member clusters in logs
-    print("\nProcess completed successfully.")
-    print("Note: Clusters with 0 or 1 members have been automatically removed,")
-    print("and articles from single-member clusters have been unlinked.")
+    logger.info("\nProcess completed successfully.")
+    logger.info("Note: Clusters with 0 or 1 members have been automatically removed,")
+    logger.info("and articles from single-member clusters have been unlinked.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This commit introduces a new utility script to fix cluster member counts by recalculating based on actual article assignments. It ensures that clusters with fewer than two members are removed, maintaining data integrity in the clustering process.

Additionally, the main clustering process now verifies and corrects any discrepancies in cluster member counts, logging the results for better traceability. This enhancement improves the accuracy of clustering operations and prevents potential issues arising from outdated member counts.