### PR TITLE
Batch update cluster counts

### DIFF
--- a/cluster_pipeline.py
+++ b/cluster_pipeline.py
@@ -11,7 +11,11 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from modules.clustering.cluster_articles import run_clustering_process
-from core.clustering.db_access import recalculate_cluster_member_counts, update_old_clusters_status
+from core.clustering.db_access import (
+    recalculate_cluster_member_counts,
+    update_old_clusters_status,
+    repair_zero_centroid_clusters,
+)
 
 # Set up logging
 logging.basicConfig(
@@ -35,7 +39,13 @@ def process_new(threshold: float = 0.82, merge_threshold: float = 0.9) -> None:
     old_clusters_count = update_old_clusters_status()
     if old_clusters_count > 0:
         logger.info(f"Updated {old_clusters_count} clusters to 'OLD' status")
-    
+
+    # Repair any clusters with zero centroid before clustering
+    logger.info("Repairing clusters with zero centroid if needed...")
+    fixed = repair_zero_centroid_clusters()
+    if fixed:
+        logger.info(f"Recalculated centroids for {len(fixed)} clusters")
+
     # Run the main clustering process
     logger.info(f"Starting article clustering workflow with threshold {threshold} and merge threshold {merge_threshold}")
     run_clustering_process(threshold, merge_threshold)

--- a/core/clustering/db_access.py
+++ b/core/clustering/db_access.py
@@ -179,95 +179,81 @@ def assign_article_to_cluster(article_id: int, cluster_id: str) -> None:
     logger.debug(f"Assigned article {article_id} to cluster {cluster_id}")
 
 def recalculate_cluster_member_counts() -> Dict[str, Tuple[int, int]]:
-    """Recalculate and update all cluster member counts based on actual article assignments.
-    
-    This function:
-    1. Counts how many articles are actually assigned to each cluster in the database
-    2. Updates the member_count field in the clusters table to match the actual count
-    3. Removes clusters with 0 members
-    4. Unlinks articles from clusters with only 1 member and deletes those clusters
-    5. Returns a dictionary with before/after counts for each cluster that had a discrepancy
-    
-    Returns:
-        Dictionary mapping cluster_id to a tuple of (old_count, new_count)
+    """Efficiently validate and correct cluster member counts.
+
+    The previous implementation queried each cluster individually which was
+    extremely chatty with the database. This version fetches all article
+    assignments in a single request and then performs batched updates and
+    deletions.  It returns a dictionary mapping the cluster ID to a tuple of
+    ``(old_count, new_count)`` for every cluster whose count changed.
     """
-    logger.info("Recalculating cluster member counts...")
-    
-    # Step 1: Get current counts from clusters table
+
+    logger.info("Recalculating cluster member counts (batch mode)...")
+
+    # Fetch current cluster counts
     clusters_resp = sb.table("clusters").select("cluster_id, member_count").execute()
     current_counts = {r["cluster_id"]: r["member_count"] for r in clusters_resp.data}
-    
-    # Step 2: Count actual articles per cluster and keep track of article IDs
-    actual_counts = {}
-    cluster_articles = {}  # To store article IDs for each cluster
-    
-    for cluster_id in current_counts.keys():
-        articles_resp = sb.table("SourceArticles").select("id").eq("cluster_id", cluster_id).execute()
-        article_ids = [r["id"] for r in articles_resp.data]
-        actual_count = len(article_ids)
-        actual_counts[cluster_id] = actual_count
-        cluster_articles[cluster_id] = article_ids
-    
-    # Step 3: Find and fix discrepancies
-    discrepancies = {}
-    for cluster_id, current_count in current_counts.items():
-        actual_count = actual_counts.get(cluster_id, 0)
-        
-        if current_count != actual_count:
-            # Record the discrepancy
-            discrepancies[cluster_id] = (current_count, actual_count)
-            
-            if actual_count >= 2:
-                # Normal case: Update the cluster count
-                sb.table("clusters").update({
-                    "member_count": actual_count,
-                    "updated_at": "now()"
-                }).eq("cluster_id", cluster_id).execute()
-                logger.info(f"Updated cluster {cluster_id} member count: {current_count} → {actual_count}")
-    
-    # Step 4: Handle special cases - empty clusters and single-member clusters
-    empty_clusters = []
-    single_member_clusters = {}
-    
-    for cluster_id, actual_count in actual_counts.items():
-        if actual_count == 0:
-            # Case 1: Empty cluster - delete it
-            empty_clusters.append(cluster_id)
-        elif actual_count == 1:
-            # Case 2: Single-member cluster - remember article ID for unlinking
-            single_member_clusters[cluster_id] = cluster_articles[cluster_id][0]
-    
-    # Step 5: Delete empty clusters
+
+    # Fetch all article assignments in one request
+    articles_resp = (
+        sb.table("SourceArticles")
+        .select("id, cluster_id")
+        .not_.is_("cluster_id", None)
+        .execute()
+    )
+
+    cluster_articles: Dict[str, List[int]] = {}
+    for row in articles_resp.data:
+        cid = row["cluster_id"]
+        cluster_articles.setdefault(cid, []).append(row["id"])
+
+    actual_counts = {cid: len(ids) for cid, ids in cluster_articles.items()}
+
+    discrepancies: Dict[str, Tuple[int, int]] = {}
+    updates: List[Dict[str, object]] = []
+    empty_clusters: List[str] = []
+    single_member_clusters: Dict[str, int] = {}
+
+    all_cluster_ids = set(current_counts.keys()) | set(actual_counts.keys())
+
+    for cid in all_cluster_ids:
+        actual = actual_counts.get(cid, 0)
+        old = current_counts.get(cid, 0)
+
+        if old != actual:
+            discrepancies[cid] = (old, actual)
+
+        if actual >= 2:
+            if actual != old:
+                updates.append({
+                    "cluster_id": cid,
+                    "member_count": actual,
+                    "updated_at": "now()",
+                })
+        elif actual == 1:
+            single_member_clusters[cid] = cluster_articles[cid][0]
+        else:
+            empty_clusters.append(cid)
+
+    if updates:
+        sb.table("clusters").upsert(updates, on_conflict="cluster_id").execute()
+        logger.info(f"Updated member counts for {len(updates)} clusters")
+
     if empty_clusters:
-        for cluster_id in empty_clusters:
-            sb.table("clusters").delete().eq("cluster_id", cluster_id).execute()
-            logger.info(f"Deleted empty cluster: {cluster_id}")
-    
-    # Step 6: Unlink articles from single-member clusters and delete those clusters
+        sb.table("clusters").delete().in_("cluster_id", empty_clusters).execute()
+        logger.info(f"Deleted {len(empty_clusters)} empty clusters")
+
     if single_member_clusters:
-        for cluster_id, article_id in single_member_clusters.items():
-            # Unlink article from cluster
-            sb.table("SourceArticles").update({
-                "cluster_id": None
-            }).eq("id", article_id).execute()
-            logger.info(f"Unlinked article {article_id} from single-member cluster {cluster_id}")
-            
-            # Delete the cluster
-            sb.table("clusters").delete().eq("cluster_id", cluster_id).execute()
-            logger.info(f"Deleted single-member cluster: {cluster_id}")
-    
-    # Log summary
-    total_fixed = len(discrepancies)
-    deleted_clusters = len(empty_clusters) + len(single_member_clusters)
-    
-    if total_fixed > 0:
-        logger.info(f"Fixed {total_fixed} cluster member count discrepancies")
+        article_ids = list(single_member_clusters.values())
+        sb.table("SourceArticles").update({"cluster_id": None}).in_("id", article_ids).execute()
+        sb.table("clusters").delete().in_("cluster_id", list(single_member_clusters.keys())).execute()
+        logger.info(f"Removed {len(single_member_clusters)} single-member clusters")
+
+    if discrepancies:
+        logger.info(f"Fixed {len(discrepancies)} cluster member count discrepancies")
     else:
         logger.info("All cluster member counts are accurate")
-        
-    if deleted_clusters > 0:
-        logger.info(f"Deleted {deleted_clusters} clusters ({len(empty_clusters)} empty, {len(single_member_clusters)} single-member)")
-    
+
     return discrepancies
 
 def update_old_clusters_status() -> int:

--- a/core/clustering/vector_utils.py
+++ b/core/clustering/vector_utils.py
@@ -40,19 +40,36 @@ def parse_embedding(embedding_str: str) -> np.ndarray:
         raise ValueError(f"Invalid embedding format: {embedding_str[:50]}...")
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
-    """Compute cosine similarity between two vectors of possibly different dimensions.
-    If dimensions don't match, the longer vector is downsampled to match the shorter one.
+    """Compute cosine similarity between two vectors.
+
+    The function is tolerant of empty or zero-dimensional arrays and will simply
+    return ``0.0`` in those cases. If the vectors differ in length by a factor of
+    two, the longer vector is downsampled to match the shorter one. Any other
+    dimensional mismatch results in ``ValueError``.
     """
+
+    a = np.asarray(a)
+    b = np.asarray(b)
+
+    if a.ndim == 0 or b.ndim == 0:
+        logger.warning("One or both vectors are scalar. Returning similarity as 0.0.")
+        return 0.0
+
+    a = a.ravel()
+    b = b.ravel()
+
+    if a.size == 0 or b.size == 0:
+        logger.warning("One or both vectors are empty. Returning similarity as 0.0.")
+        return 0.0
+
     # Handle dimension mismatch
-    if a.shape[0] != b.shape[0]:
-        # If a is twice as long as b, downsample a
-        if a.shape[0] == b.shape[0] * 2:
+    if a.size != b.size:
+        if a.size == b.size * 2:
             a = a[::2]
-        # If b is twice as long as a, downsample b
-        elif b.shape[0] == a.shape[0] * 2:
+        elif b.size == a.size * 2:
             b = b[::2]
         else:
-            raise ValueError(f"Incompatible dimensions: {a.shape[0]} and {b.shape[0]}")
+            raise ValueError(f"Incompatible dimensions: {a.size} and {b.size}")
     
     # Compute norms
     norm_a = np.linalg.norm(a)

--- a/tests/test_batch_count.py
+++ b/tests/test_batch_count.py
@@ -1,0 +1,81 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+db_access = None
+
+class DummyTable:
+    def __init__(self, data):
+        self.data = data
+        self.upsert_calls = []
+        self.update_calls = []
+        self.delete_filters = []
+    def select(self, *args, **kwargs):
+        return self
+    @property
+    def not_(self):
+        return self
+    def is_(self, *args, **kwargs):
+        return self
+    def eq(self, *args, **kwargs):
+        return self
+    def in_(self, *args):
+        self.delete_filters.append(args)
+        return self
+    def update(self, data):
+        self.update_calls.append(data)
+        return self
+    def delete(self):
+        self.delete_called = True
+        return self
+    def upsert(self, data, on_conflict=None):
+        self.upsert_calls.append((data, on_conflict))
+        return self
+    def execute(self):
+        return SimpleNamespace(data=self.data)
+
+class DummySB:
+    def __init__(self, clusters, articles):
+        self.tables = {
+            "clusters": DummyTable(clusters),
+            "SourceArticles": DummyTable(articles),
+        }
+    def table(self, name):
+        return self.tables[name]
+
+def test_recalculate_member_counts_batch(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "member_count": 1},
+        {"cluster_id": "c2", "member_count": 5},
+    ]
+    articles = [
+        {"id": 1, "cluster_id": "c1"},
+        {"id": 2, "cluster_id": "c2"},
+        {"id": 3, "cluster_id": "c2"},
+        {"id": 4, "cluster_id": "c3"},
+        {"id": 5, "cluster_id": "c3"},
+    ]
+    dummy = DummySB(clusters, articles)
+
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    discrepancies = db_access.recalculate_cluster_member_counts()
+
+    upserts = dummy.tables["clusters"].upsert_calls
+    deletes = dummy.tables["clusters"].delete_filters
+    updates = dummy.tables["SourceArticles"].update_calls
+
+    assert {c["cluster_id"] for c in upserts[0][0]} == {"c2", "c3"}
+    assert any("cluster_id" in d[0] and "c1" in d[1] for d in deletes)
+    assert updates and updates[0] == {"cluster_id": None}
+    assert discrepancies.get("c2") == (5, 2)

--- a/tests/test_vector_utils.py
+++ b/tests/test_vector_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+from core.clustering.vector_utils import cosine_similarity
+
+
+def test_cosine_similarity_with_empty_inputs():
+    assert cosine_similarity(np.array([]), np.array([])) == 0.0
+
+
+def test_cosine_similarity_with_scalar_inputs():
+    assert cosine_similarity(np.array(0.5), np.array(0.5)) == 0.0

--- a/tests/test_zero_centroid_fix.py
+++ b/tests/test_zero_centroid_fix.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+class DummyTable:
+    def __init__(self, data):
+        self.data = data
+        self.filters = []
+    def select(self, *args, **kwargs):
+        return self
+    def eq(self, key, value):
+        self.filters.append((key, value))
+        return self
+    def execute(self):
+        result = self.data
+        for key, value in self.filters:
+            result = [row for row in result if row.get(key) == value]
+        self.filters = []
+        return SimpleNamespace(data=result)
+
+class DummySB:
+    def __init__(self, clusters, articles):
+        self.tables = {
+            "clusters": DummyTable(clusters),
+            "SourceArticles": DummyTable(articles),
+        }
+    def table(self, name):
+        return self.tables[name]
+
+def test_repair_zero_centroid_clusters(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "centroid": [0.0, 0.0, 0.0]},
+        {"cluster_id": "c2", "centroid": [0.1, 0.2, 0.3]},
+    ]
+    articles = [
+        {"id": 1, "cluster_id": "c1", "ArticleVector": [{"embedding": "[1,0,0]"}]},
+        {"id": 2, "cluster_id": "c1", "ArticleVector": [{"embedding": "[0,1,0]"}]},
+        {"id": 3, "cluster_id": "c2", "ArticleVector": [{"embedding": "[0.1,0.2,0.3]"}]},
+    ]
+
+    dummy = DummySB(clusters, articles)
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    updates = []
+    def dummy_update(cid, centroid, count, isContent=False):
+        updates.append((cid, centroid.tolist(), count))
+    monkeypatch.setattr(db_access, "update_cluster_in_db", dummy_update)
+
+    fixed = db_access.repair_zero_centroid_clusters()
+
+    assert fixed == ["c1"]
+    assert updates
+    cid, centroid, count = updates[0]
+    assert cid == "c1"
+    assert count == 2
+    assert centroid == [0.5, 0.5, 0.0]


### PR DESCRIPTION
## Summary
- optimize `recalculate_cluster_member_counts` by batching updates
- cover new logic with `test_batch_count`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cd3a250c83208485802fce427de6