### PR TITLE
Fix handling of clusters with NULL centroids

### DIFF
--- a/cluster_pipeline.py
+++ b/cluster_pipeline.py
@@ -11,7 +11,11 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from modules.clustering.cluster_articles import run_clustering_process
-from core.clustering.db_access import recalculate_cluster_member_counts, update_old_clusters_status
+from core.clustering.db_access import (
+    recalculate_cluster_member_counts,
+    update_old_clusters_status,
+    repair_zero_centroid_clusters,
+)
 
 # Set up logging
 logging.basicConfig(
@@ -35,7 +39,13 @@ def process_new(threshold: float = 0.82, merge_threshold: float = 0.9) -> None:
     old_clusters_count = update_old_clusters_status()
     if old_clusters_count > 0:
         logger.info(f"Updated {old_clusters_count} clusters to 'OLD' status")
-    
+
+    # Repair any clusters with zero centroid before clustering
+    logger.info("Repairing clusters with zero centroid if needed...")
+    fixed = repair_zero_centroid_clusters()
+    if fixed:
+        logger.info(f"Recalculated centroids for {len(fixed)} clusters")
+
     # Run the main clustering process
     logger.info(f"Starting article clustering workflow with threshold {threshold} and merge threshold {merge_threshold}")
     run_clustering_process(threshold, merge_threshold)

--- a/core/clustering/vector_utils.py
+++ b/core/clustering/vector_utils.py
@@ -40,19 +40,36 @@ def parse_embedding(embedding_str: str) -> np.ndarray:
         raise ValueError(f"Invalid embedding format: {embedding_str[:50]}...")
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
-    """Compute cosine similarity between two vectors of possibly different dimensions.
-    If dimensions don't match, the longer vector is downsampled to match the shorter one.
+    """Compute cosine similarity between two vectors.
+
+    The function is tolerant of empty or zero-dimensional arrays and will simply
+    return ``0.0`` in those cases. If the vectors differ in length by a factor of
+    two, the longer vector is downsampled to match the shorter one. Any other
+    dimensional mismatch results in ``ValueError``.
     """
+
+    a = np.asarray(a)
+    b = np.asarray(b)
+
+    if a.ndim == 0 or b.ndim == 0:
+        logger.warning("One or both vectors are scalar. Returning similarity as 0.0.")
+        return 0.0
+
+    a = a.ravel()
+    b = b.ravel()
+
+    if a.size == 0 or b.size == 0:
+        logger.warning("One or both vectors are empty. Returning similarity as 0.0.")
+        return 0.0
+
     # Handle dimension mismatch
-    if a.shape[0] != b.shape[0]:
-        # If a is twice as long as b, downsample a
-        if a.shape[0] == b.shape[0] * 2:
+    if a.size != b.size:
+        if a.size == b.size * 2:
             a = a[::2]
-        # If b is twice as long as a, downsample b
-        elif b.shape[0] == a.shape[0] * 2:
+        elif b.size == a.size * 2:
             b = b[::2]
         else:
-            raise ValueError(f"Incompatible dimensions: {a.shape[0]} and {b.shape[0]}")
+            raise ValueError(f"Incompatible dimensions: {a.size} and {b.size}")
     
     # Compute norms
     norm_a = np.linalg.norm(a)

--- a/tests/test_batch_count.py
+++ b/tests/test_batch_count.py
@@ -1,0 +1,81 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+db_access = None
+
+class DummyTable:
+    def __init__(self, data):
+        self.data = data
+        self.upsert_calls = []
+        self.update_calls = []
+        self.delete_filters = []
+    def select(self, *args, **kwargs):
+        return self
+    @property
+    def not_(self):
+        return self
+    def is_(self, *args, **kwargs):
+        return self
+    def eq(self, *args, **kwargs):
+        return self
+    def in_(self, *args):
+        self.delete_filters.append(args)
+        return self
+    def update(self, data):
+        self.update_calls.append(data)
+        return self
+    def delete(self):
+        self.delete_called = True
+        return self
+    def upsert(self, data, on_conflict=None):
+        self.upsert_calls.append((data, on_conflict))
+        return self
+    def execute(self):
+        return SimpleNamespace(data=self.data)
+
+class DummySB:
+    def __init__(self, clusters, articles):
+        self.tables = {
+            "clusters": DummyTable(clusters),
+            "SourceArticles": DummyTable(articles),
+        }
+    def table(self, name):
+        return self.tables[name]
+
+def test_recalculate_member_counts_batch(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "member_count": 1},
+        {"cluster_id": "c2", "member_count": 5},
+    ]
+    articles = [
+        {"id": 1, "cluster_id": "c1"},
+        {"id": 2, "cluster_id": "c2"},
+        {"id": 3, "cluster_id": "c2"},
+        {"id": 4, "cluster_id": "c3"},
+        {"id": 5, "cluster_id": "c3"},
+    ]
+    dummy = DummySB(clusters, articles)
+
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    discrepancies = db_access.recalculate_cluster_member_counts()
+
+    upserts = dummy.tables["clusters"].upsert_calls
+    deletes = dummy.tables["clusters"].delete_filters
+    updates = dummy.tables["SourceArticles"].update_calls
+
+    assert {c["cluster_id"] for c in upserts[0][0]} == {"c2", "c3"}
+    assert any("cluster_id" in d[0] and "c1" in d[1] for d in deletes)
+    assert updates and updates[0] == {"cluster_id": None}
+    assert discrepancies.get("c2") == (5, 2)

--- a/tests/test_fetch_existing_clusters.py
+++ b/tests/test_fetch_existing_clusters.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+class DummyTable:
+    def __init__(self, data):
+        self.data = data
+    def select(self, *args, **kwargs):
+        return self
+    def execute(self):
+        return SimpleNamespace(data=self.data)
+
+class DummySB:
+    def __init__(self, clusters):
+        self.tables = {
+            "clusters": DummyTable(clusters),
+        }
+    def table(self, name):
+        return self.tables[name]
+
+
+def test_fetch_existing_clusters_skips_null(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "centroid": None, "member_count": 2},
+        {"cluster_id": "c2", "centroid": [0.1, 0.2], "member_count": 1},
+    ]
+
+    dummy = DummySB(clusters)
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    result = db_access.fetch_existing_clusters()
+    assert len(result) == 1
+    cid, centroid, count = result[0]
+    assert cid == "c2"
+    assert count == 1

--- a/tests/test_vector_utils.py
+++ b/tests/test_vector_utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+from core.clustering.vector_utils import cosine_similarity
+
+
+def test_cosine_similarity_with_empty_inputs():
+    assert cosine_similarity(np.array([]), np.array([])) == 0.0
+
+
+def test_cosine_similarity_with_scalar_inputs():
+    assert cosine_similarity(np.array(0.5), np.array(0.5)) == 0.0

--- a/tests/test_zero_centroid_fix.py
+++ b/tests/test_zero_centroid_fix.py
@@ -1,0 +1,101 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+class DummyTable:
+    def __init__(self, data):
+        self.data = data
+        self.filters = []
+    def select(self, *args, **kwargs):
+        return self
+    def eq(self, key, value):
+        self.filters.append((key, value))
+        return self
+    def execute(self):
+        result = self.data
+        for key, value in self.filters:
+            result = [row for row in result if row.get(key) == value]
+        self.filters = []
+        return SimpleNamespace(data=result)
+
+class DummySB:
+    def __init__(self, clusters, articles):
+        self.tables = {
+            "clusters": DummyTable(clusters),
+            "SourceArticles": DummyTable(articles),
+        }
+    def table(self, name):
+        return self.tables[name]
+
+def test_repair_zero_centroid_clusters(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "centroid": [0.0, 0.0, 0.0]},
+        {"cluster_id": "c2", "centroid": [0.1, 0.2, 0.3]},
+    ]
+    articles = [
+        {"id": 1, "cluster_id": "c1", "ArticleVector": [{"embedding": "[1,0,0]"}]},
+        {"id": 2, "cluster_id": "c1", "ArticleVector": [{"embedding": "[0,1,0]"}]},
+        {"id": 3, "cluster_id": "c2", "ArticleVector": [{"embedding": "[0.1,0.2,0.3]"}]},
+    ]
+
+    dummy = DummySB(clusters, articles)
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    updates = []
+    def dummy_update(cid, centroid, count, isContent=False):
+        updates.append((cid, centroid.tolist(), count))
+    monkeypatch.setattr(db_access, "update_cluster_in_db", dummy_update)
+
+    fixed = db_access.repair_zero_centroid_clusters()
+
+    assert fixed == ["c1"]
+    assert updates
+    cid, centroid, count = updates[0]
+    assert cid == "c1"
+    assert count == 2
+    assert centroid == [0.5, 0.5, 0.0]
+
+
+def test_repair_null_centroid_clusters(monkeypatch):
+    clusters = [
+        {"cluster_id": "c1", "centroid": None},
+        {"cluster_id": "c2", "centroid": [0.1, 0.2, 0.3]},
+    ]
+    articles = [
+        {"id": 1, "cluster_id": "c1", "ArticleVector": [{"embedding": "[1,0,0]"}]},
+        {"id": 2, "cluster_id": "c1", "ArticleVector": [{"embedding": "[0,1,0]"}]},
+    ]
+
+    dummy = DummySB(clusters, articles)
+    monkeypatch.setitem(sys.modules, "supabase", mock.MagicMock(create_client=lambda u, k: dummy))
+    monkeypatch.setenv("SUPABASE_URL", "http://x")
+    monkeypatch.setenv("SUPABASE_KEY", "y")
+
+    import importlib
+    import core.clustering.db_access as db_module
+    db_access = importlib.reload(db_module)
+    monkeypatch.setattr(db_access, "sb", dummy)
+
+    updates = []
+    def dummy_update(cid, centroid, count, isContent=False):
+        updates.append((cid, centroid.tolist(), count))
+    monkeypatch.setattr(db_access, "update_cluster_in_db", dummy_update)
+
+    fixed = db_access.repair_zero_centroid_clusters()
+
+    assert fixed == ["c1"]
+    assert updates
+    cid, centroid, count = updates[0]
+    assert cid == "c1"
+    assert count == 2
+    assert centroid == [0.5, 0.5, 0.0]


### PR DESCRIPTION
## Summary
- skip clusters with `NULL` centroid when loading existing clusters
- treat `NULL` centroid the same as all-zero in `repair_zero_centroid_clusters`
- add regression tests for both behaviours

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cd3a250c83208485802fce427de6