### PR TITLE
Fix parse_embedding tests

### DIFF
--- a/tests/test_parse_embedding.py
+++ b/tests/test_parse_embedding.py
@@ -12,9 +12,13 @@ from core.clustering.vector_utils import parse_embedding
     ],
 )
 def test_parse_embedding(input_str, expected):
-    if isinstance(expected, pytest.raises):
-        with expected:
-            parse_embedding(input_str)
-    else:
+    """Ensure ``parse_embedding`` parses valid strings and raises errors for
+    invalid input."""
+
+    # ``expected`` is either a numpy array or a ``pytest.raises`` context
+    if isinstance(expected, np.ndarray):
         emb = parse_embedding(input_str)
         assert np.allclose(emb, expected)
+    else:
+        with expected:
+            parse_embedding(input_str)


### PR DESCRIPTION
## Summary
- adjust parse_embedding test to check for numpy arrays
- verify parse_embedding raises errors correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515b1e19508320917ab140b434bd4d