### PR TITLE
Fix monkeypatch setup in tests

### DIFF
--- a/tests/test_cluster_manager.py
+++ b/tests/test_cluster_manager.py
@@ -4,15 +4,13 @@ import sys
 from types import SimpleNamespace
 from unittest import mock
 import numpy as np
+import pytest
 
 # Ensure modules can be reloaded with patched dependencies
 @pytest.fixture(autouse=True)
 def _prepend_parent_dir_to_syspath(monkeypatch):
     parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     monkeypatch.syspath_prepend(parent_dir)
-
-
-import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_normalize_embedding.py
+++ b/tests/test_normalize_embedding.py
@@ -1,6 +1,8 @@
 import os
+import sys
 import numpy as np
 import importlib
+from types import ModuleType
 from unittest import mock
 import pytest
 
@@ -10,8 +12,13 @@ os.environ.setdefault("OPENAI_API_KEY", "testkey")
 
 @pytest.fixture
 def ce_fixture():
-    with mock.patch("supabase.create_client", return_value=mock.Mock()), \
-         mock.patch("openai.OpenAI", return_value=mock.Mock()):
+    supabase_mock = ModuleType("supabase")
+    supabase_mock.create_client = mock.Mock(return_value=mock.Mock())
+    supabase_mock.Client = mock.Mock()
+    openai_mock = ModuleType("openai")
+    openai_mock.OpenAI = mock.Mock(return_value=mock.Mock())
+
+    with mock.patch.dict(sys.modules, {"supabase": supabase_mock, "openai": openai_mock}):
         ce = importlib.import_module("core.utils.create_embeddings")
         yield ce
 


### PR DESCRIPTION
## Summary
- import `pytest` before use in `test_cluster_manager`
- create dummy `supabase` and `openai` modules for `test_normalize_embedding`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516bc6f6248320a22b68d8bb81604f